### PR TITLE
chore: add reusable create-monthly-milestones workflow

### DIFF
--- a/.github/workflows/create-monthly-milestones.yml
+++ b/.github/workflows/create-monthly-milestones.yml
@@ -1,0 +1,43 @@
+name: Create Monthly Milestones (reusable)
+
+on:
+  workflow_call:
+
+jobs:
+  create-milestone:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Calculate next month milestone
+        id: next-month
+        run: |
+          CURRENT_YEAR=$(date +%Y)
+          CURRENT_MONTH=$(date +%m)
+
+          if [ "$CURRENT_MONTH" = "12" ]; then
+            NEXT_YEAR=$((CURRENT_YEAR + 1))
+            NEXT_MONTH="01"
+          else
+            NEXT_YEAR=$CURRENT_YEAR
+            NEXT_MONTH=$(printf "%02d" "$(( 10#$CURRENT_MONTH + 1 ))")
+          fi
+
+          MILESTONE_TITLE="v${NEXT_YEAR}.${NEXT_MONTH}"
+          echo "milestone=$MILESTONE_TITLE" >> "$GITHUB_OUTPUT"
+          echo "Next month milestone: $MILESTONE_TITLE"
+
+      - name: Create milestone
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          MILESTONE_TITLE="${{ steps.next-month.outputs.milestone }}"
+
+          if gh api "repos/$REPO/milestones" --paginate --jq '.[].title' | grep -qx "$MILESTONE_TITLE"; then
+            echo "Milestone already exists: $MILESTONE_TITLE"
+          else
+            gh api --method POST "repos/$REPO/milestones" -f title="$MILESTONE_TITLE"
+            echo "Created milestone: $MILESTONE_TITLE"
+          fi


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/create-monthly-milestones.yml` as a `workflow_call` reusable workflow
- Drops `actions/checkout` (the script only calls `gh api` and `date` — no repo files needed)
- Drops `contents: read` permission (no checkout = no read needed)
- Replaces hardcoded `Inscorep/<repo>` slugs with `${{ github.repository }}` — rename-safe

## Tracking

Part of Inscorep/issues-inscorep#140 — must merge before the 4 consumer PRs can go live.

Consumer repos (PRs to open after this merges):
- `Inscorep/issues-compass`
- `Inscorep/issues-lombard`
- `Inscorep/app-service-sigma-backend`
- `Inscorep/app-service-sigma-frontend`

## Verification

After merge: `gh workflow view "Create Monthly Milestones (reusable)" -R Inscorep/.github` should list the workflow as registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)